### PR TITLE
chore: bump bytes for overflow fix and clean sender unwrap

### DIFF
--- a/.tasks/tk-4rhj.json
+++ b/.tasks/tk-4rhj.json
@@ -1,0 +1,28 @@
+{
+  "project": "tk",
+  "ref": "4rhj",
+  "title": "Review PR21 and apply bytes overflow fix",
+  "description": "Inspect PR #21 dependency bump for bytes integer overflow fix, update main dependencies safely, validate build/tests, and summarize PR #13 ideas compatible with current streaming architecture.",
+  "status": "active",
+  "priority": 2,
+  "labels": [],
+  "assignees": [],
+  "parent": null,
+  "blocked_by": [],
+  "estimate": null,
+  "due_date": null,
+  "logs": [
+    {
+      "ts": "2026-02-11T01:11:02.281Z",
+      "msg": "Applied bytes 1.11.1 bump locally and validated with cargo build + cargo test (all passing, existing SSH integration tests remain ignored)."
+    },
+    {
+      "ts": "2026-02-11T01:13:19.400Z",
+      "msg": "PR #13 assessed at idea level: 1073 files / 22463 additions with broad scope (daemon, python bindings, CLI utilities, temp benchmark artifacts). Recommendation is selective adoption only (daemon architecture concept, progress callback model) and avoid cherry-picking code."
+    }
+  ],
+  "created_at": "2026-02-11T01:09:12.526Z",
+  "updated_at": "2026-02-11T01:13:19.400Z",
+  "completed_at": null,
+  "external": {}
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,9 +211,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "byteview"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ fjall = "2.11.2"
 
 # S3 / Cloud Storage (Phase 10) - Optional feature
 object_store = { version = "0.12.4", features = ["aws", "gcp"], optional = true }
-bytes = "1.10.1"
+bytes = "1.11.1"
 crossbeam-channel = "0.5.15"
 memmap2 = "0.9.9"
 bitflags = "2.10.0"

--- a/ai/STATUS.md
+++ b/ai/STATUS.md
@@ -10,6 +10,12 @@
 
 ## Active Work
 
+**2026-02-11: Dependency Security + PR Review**
+
+- Applied PR #21-equivalent dependency update: `bytes` `1.10.1` → `1.11.1` (overflow fix)
+- Validation complete: `cargo build`, `cargo test`, and `cargo clippy -- -D warnings` all pass
+- Extracted architecture-aligned ideas from PR #13 (no direct cherry-pick due scale/scope mismatch)
+
 **2026-01-19: v0.3.0 Released**
 
 - Streaming protocol v2 merged to main

--- a/src/streaming/sender.rs
+++ b/src/streaming/sender.rs
@@ -106,10 +106,15 @@ impl Sender {
         on_data(entry.encode())?;
 
         // Read and send data chunks
-        if job.need_delta && job.checksums.is_some() {
-            // Delta transfer
-            self.send_delta(&full_path, &path_str, job.checksums.unwrap(), on_data)
-                .await?;
+        if job.need_delta {
+            if let Some(checksums) = job.checksums {
+                // Delta transfer
+                self.send_delta(&full_path, &path_str, checksums, on_data)
+                    .await?;
+            } else {
+                // No destination checksums available, fall back to full transfer.
+                self.send_full(&full_path, &path_str, on_data).await?;
+            }
         } else {
             // Full transfer
             self.send_full(&full_path, &path_str, on_data).await?;


### PR DESCRIPTION
## Summary
- bump `bytes` from `1.10.1` to `1.11.1` (includes `BytesMut::reserve` integer-overflow fix)
- update lockfile accordingly
- replace an unnecessary `unwrap()` in `streaming::sender::process_file` with explicit branching
- update AI status/task records for this work

## Validation
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`

## Context
- Equivalent to Dependabot PR #21 for bytes security fix.
- PR #13 was reviewed at idea level only (not code cherry-pick) due major scope drift and stale fork context.
