### PR TITLE
fix: release audit safety gaps (v0.4.0)

### DIFF
--- a/src/bin/sy-remote.rs
+++ b/src/bin/sy-remote.rs
@@ -251,6 +251,7 @@ fn main() -> anyhow::Result<()> {
 
             // Write file atomically: temp + rename
             let temp_path = TempFileGuard::temp_path_for(&output_path);
+            let temp_guard = TempFileGuard::new(&temp_path);
             {
                 let mut temp_file = std::fs::File::create(&temp_path)?;
                 temp_file.write_all(&file_data)?;
@@ -268,6 +269,7 @@ fn main() -> anyhow::Result<()> {
             }
             // Atomic rename to final path
             std::fs::rename(&temp_path, &output_path)?;
+            temp_guard.defuse();
 
             // Report success with bytes written
             println!("{{\"bytes_written\": {}}}", file_data.len());


### PR DESCRIPTION
## Summary
Closes all release audit findings:
- Atomic writes on all local copy paths (copy_file, copy_file_streaming, sparse/fallback)
- Atomic writes on sy-remote ReceiveFile + ReceiveSparseFile
- Source deletion after verification (--remove-source-files --verify)
- SSH pull delete threshold wired through Hello protocol
- Temp file naming uses monotonic counter
- Protocol length guards, streaming filter/scan options, exact mtime comparison
- BSD flags JSON propagation, compression_detection config threading
- Lock file truncate(false), setuid/setgid stripping in streaming receiver
- Temp guard on ReceiveFile to prevent temp leak on early error
- No TODO/FIXME in src/

## Verification
- cargo test: 594 pass
- cargo test --test sync_ssh -- --ignored --test-threads=1: 19/19 pass
- cargo clippy -- -D warnings: clean
- cargo fmt --check: clean
- cargo bench --no-run: compiles
- Dependabot: 0 open

## P2 deferred (pre-existing, not introduced by this PR)
- Pull-mode filter propagation (server scans unfiltered in PULL mode)
- --dirs not wired in pull mode